### PR TITLE
Update Alpine image to version 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.16
 
 RUN apk add -U bash git dos2unix
 


### PR DESCRIPTION
### Why:
We're using this action for a while (3 years) and it is still being built based on a outdated alpine version. A docker scan showed that it has a critical vulnerability that it's fixed on later versions.
![Screenshot 2022-06-15 at 18 05 51](https://user-images.githubusercontent.com/1515983/173885166-7ba2b829-4106-455e-9828-4f30f39956bc.png)
More info: https://security.snyk.io/vuln/SNYK-ALPINE310-APKTOOLS-1534688

Doing the same scan when using alpine:3.16 showed no known vulnerabilities.
![Screenshot 2022-06-15 at 18 07 46](https://user-images.githubusercontent.com/1515983/173885491-f768fadf-f69e-4a3f-a115-4f2d59b151c1.png)

Also, since the action has no changes for a while, it's best if we keep doing security updates while we still use it.

### This addresses the issue by:
- Update docker container alpine:3.10 to alpine:3.16 (latest ATOW)
