### PR TITLE
Attempt to merge changes from heroku before pushing new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           ref: master # you can use this to get a non-detached head but it's not strictly required
-      - uses: ilkka/git-https-push-action@master
+      - uses: utrustdev/git-https-push-action@master
         name: Deploy
         with:
           remoteUrl: ${{ secrets.PUSH_REMOTE }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,5 +20,4 @@ fi
 
 git config --global --add safe.directory /github/workspace
 git remote add $REMOTE $REMOTE_URL
-git pull
-git push $(join_by " " $EXTRA_ARGS) $REMOTE HEAD:master
+git push --force $(join_by " " $EXTRA_ARGS) $REMOTE HEAD:master

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,4 +20,5 @@ fi
 
 git config --global --add safe.directory /github/workspace
 git remote add $REMOTE $REMOTE_URL
+git pull
 git push $(join_by " " $EXTRA_ARGS) $REMOTE HEAD:master


### PR DESCRIPTION
### Why:
When trying to push changes to heroku, sometimes it gets stuck because there are some changes made from someone else besides this action which means that it needs to merge those changes to the branch its trying to push. We only want to manage deploys via this action so there's no need to be careful when pushing changes to heroku.

### This addresses the issue by:
- Adding `--force` to git push so it is always able to deploy.